### PR TITLE
Use DateTime.UtcNow as default finish date

### DIFF
--- a/src/Fynance/YahooTicker.cs
+++ b/src/Fynance/YahooTicker.cs
@@ -121,7 +121,7 @@
 
 				// Set current datetime for' FinishDate' when it is not defined.
 				if (FinishDate == null)
-					FinishDate = DateTime.Now;
+					FinishDate = DateTime.UtcNow;
 
 				// Validate the Start/Finish interval.
 				if (StartDate > FinishDate)


### PR DESCRIPTION
From what I can see yahoo finance always seems to refer to dates as UTC. DateTime.Now is only going to work for half of the timezone.  DateTime.UtcNow should fix that