### PR TITLE
Prevent rate limit to result in NRE

### DIFF
--- a/src/Fynance/YahooTicker.cs
+++ b/src/Fynance/YahooTicker.cs
@@ -64,10 +64,9 @@
 				yResponse = JsonConvert.DeserializeObject<YResponse>(responseBody);
 
 			// When the http request does not succeed
-			if (!response.IsSuccessStatusCode || yResponse == null)
+			var error = yResponse?.Chart?.Error;
+			if (!response.IsSuccessStatusCode || yResponse == null || error != null)
 			{
-				var error = yResponse?.Chart?.Error;
-
 				string code = "Fynance.Yahoo";
 				string message = "This result was not possible to get from Yahoo Finance.";
 


### PR DESCRIPTION
It seems like it is totally possible to get IsSuccessStatusCode = true, yResponse != null and an error. 

I have been able to reproduce this by sending a big amount of request to the API and getting an error code internal-error from yahoo 
I guess they return this when rate limiting

Without this code it end up throwing a NullReferenceException in GetResult